### PR TITLE
release v2024.2.26 (with publish fixes) 

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,7 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2023-2024 Northwestern University.
+#
+
 on:
   push:
     tags:
-      - v*
+      - 'v*!rc*'
 
 jobs:
   build-n-publish:
@@ -13,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2023 Northwestern University.
+# Copyright (C) 2023-2024 Northwestern University.
 #
-
-name: Tests for invenio-subjects-mesh
 
 on:
   push:
-    branches: master
+    branches:
+      - master
   pull_request:
-    branches: master
+    branches:
+      - master
   workflow_dispatch:
     inputs:
       reason:
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-          python-version: ["3.8", "3.9", "3.10", "3.11"]
+          python-version: ["3.8", "3.9", "3.10"]
           requirements-level: [pypi]
 
     steps:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021 Northwestern University.
+# Copyright (C) 2021-2024 Northwestern University.
 #
 # invenio-subjects-mesh is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -15,4 +15,5 @@
 include *.md
 recursive-include invenio_subjects_mesh *.yaml
 recursive-include invenio_subjects_mesh *.jsonl
+recursive-include invenio_subjects_mesh *.csv
 recursive-include tests *.py

--- a/README.md
+++ b/README.md
@@ -41,38 +41,34 @@ There are 2 types of users for this package. Instance administrators and package
 
 For instance administrators, after you have installed the extension as per the steps above, you will want to reload your instance's fixtures: `pipenv run invenio rdm-records fixtures`. This will install the new terms in your instance.
 
-Updating existing terms currently requires manual replacement.
+Alternatively, or if you want to update your already loaded subjects to a new listing (e.g. from one year's list to another), you can update your instance's MeSH subjects as per below. Updating subjects this way takes care of everything for you: the subjects themselves and the records/drafts using those subjects. **WARNING** This operation can _remove_ subjects.
+
+```bash
+# In your instance's project
+# Download up-to-date listings
+pipenv run invenio galter_subjects mesh download -d /path/to/downloads/storage/ -y YEAR
+# Generate file containg deltas to transition your instance to the downloaded listing
+pipenv run invenio galter_subjects mesh deltas -d /path/to/downloads/storage/ -y YEAR -f topic-qualifier -o deltas_mesh.csv
+# Update your instance - *this operation will modify your instance*
+pipenv run invenio galter_subjects update deltas_mesh.csv
+```
+
+Look at the help text for these commands to see additional options that can be passed.
+In particular, options for `galter_subjects update` allow you to store renamed, replaced or removed subjects on records according to a template of your choice.
 
 ### Maintainers
 
 When a new list of MeSH term comes out, this package should be updated. Here we show how.
 
-0. Install this package locally with the `dev` extra:
-
 ```bash
-pipenv run pip install -e .[dev]
+# In this project
+# Download up-to-date listings
+pipenv run invenio galter_subjects mesh download -d /path/to/downloads/storage/ -y YEAR
+# Generate file containing initial listing
+pipenv run invenio galter_subjects mesh file -d /path/to/downloads/storage/ -y YEAR -f topic-qualifier -o invenio_subjects_mesh/vocabularies/subjects_mesh.csv
 ```
 
-1. Use the installed `galter-subjects-utils` tool to get the new list:
-
-```bash
-pipenv run galter-subjects-utils mesh --filter topic-qualifier --output-file invenio_subjects_mesh/vocabularies/subjects_mesh.jsonl
-```
-
-   This will
-
-   1. Download the new list(s)
-   2. Read it filtering for topics
-   3. Convert terms to InvenioRDM subjects format
-   4. Write those to the specified file
-
-2. Check the manifest (it should typically be all good)
-
-```bash
-pipenv run inv check-manifest
-```
-
-3. When you are happy with the list, bump the version and release it.
+When you are happy with the list, bump the version in `pyproject.toml` and release it.
 
 ## Development
 

--- a/invenio_subjects_mesh/__init__.py
+++ b/invenio_subjects_mesh/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2021-2023 Northwestern University.
+# Copyright (C) 2021-2024 Northwestern University.
 #
 # invenio-subjects-mesh is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,4 +9,4 @@
 """MeSH subject terms for InvenioRDM."""
 
 
-__version__ = '2023.01.3'
+__version__ = '2024.02.26'

--- a/invenio_subjects_mesh/vocabularies/vocabularies.yaml
+++ b/invenio_subjects_mesh/vocabularies/vocabularies.yaml
@@ -2,6 +2,6 @@ subjects:
   pid-type: sub
   schemes:
     - id: MeSH
-      data-file: subjects_mesh.jsonl
+      data-file: subjects_mesh.csv
       name: Medical Subject Headings
       uri: "https://www.nlm.nih.gov/mesh/meshhome.html"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,10 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11"
 ]
-dependencies = []
+dependencies = [
+    "galter-subjects-utils>=0.3.1,<2.0",
+]
 description = "MeSH subject terms with qualifiers"
 dynamic = ["version"]
 keywords = ["invenio", "inveniordm", "subjects", "MeSH"]
@@ -34,13 +35,8 @@ urls = {Repository = "https://github.com/galterlibrary/invenio-subjects-mesh"}
 dev = [
     "check-manifest>=0.49",
     "invoke>=2.2,<3.0",
-    "galter-subjects-utils>=0.1.0,<2.0",
     "pyyaml>=5.4.1",
-    "pytest>=7.2.0",
-    "pytest-cov>=3.0.0",
-    "pytest-isort>=3.0.0",
-    "pytest-pycodestyle>=2.2.0",
-    "pytest-pydocstyle>=2.2.3"
+    "pytest-invenio>=2.1.1,<3.0.0",
 ]
 
 [project.entry-points."invenio_rdm_records.fixtures"]


### PR DESCRIPTION
- closes https://github.com/galterlibrary/invenio-subjects-mesh/issues/10
- bump galter-subjects-utils to v0.3 + update vocab file
- polish for 2024.2.26 release
- release: v2024.2.26

